### PR TITLE
Fixing host dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - python >=3.11
     - setuptools
     - setuptools-scm
+    - pip
 
   run:
     - python >=3.11


### PR DESCRIPTION
Build is failing on feedstock, probably because pip was missing in the host dependencies.